### PR TITLE
Fix build on mac; add raylib color constants

### DIFF
--- a/examples/simple_window.onyx
+++ b/examples/simple_window.onyx
@@ -16,7 +16,7 @@ main :: () {
 
         pos := raylib.GetMousePosition();
         pos_text := core.tprintf("{}\0", pos);
-        
+
         r := raylib.Rectangle.{
             100, 150, 300, 200
         };
@@ -27,7 +27,7 @@ main :: () {
         }
 
         raylib.BeginDrawing();
-        raylib.ClearBackground(.{40, 40, 40, 255});
+        raylib.ClearBackground(raylib.BLACK);
         raylib.DrawRectangleRec(r, r_color);
         raylib.DrawText(pos_text.data, 100, 100, 10, .{255, 0, 0, 255});
         raylib.DrawFPS(0, 0);

--- a/module.onyx
+++ b/module.onyx
@@ -12,6 +12,32 @@ use cbindgen {*}
     #library PACKAGE_NAME
 }
 
+LIGHTGRAY  :: Color.{ 200, 200, 200, 255 };   // Light Gray
+GRAY       :: Color.{ 130, 130, 130, 255 };   // Gray
+DARKGRAY   :: Color.{ 80, 80, 80, 255 };      // Dark Gray
+YELLOW     :: Color.{ 253, 249, 0, 255 };     // Yellow
+GOLD       :: Color.{ 255, 203, 0, 255 };     // Gold
+ORANGE     :: Color.{ 255, 161, 0, 255 };     // Orange
+PINK       :: Color.{ 255, 109, 194, 255 };   // Pink
+RED        :: Color.{ 230, 41, 55, 255 };     // Red
+MAROON     :: Color.{ 190, 33, 55, 255 };     // Maroon
+GREEN      :: Color.{ 0, 228, 48, 255 };      // Green
+LIME       :: Color.{ 0, 158, 47, 255 };      // Lime
+DARKGREEN  :: Color.{ 0, 117, 44, 255 };      // Dark Green
+SKYBLUE    :: Color.{ 102, 191, 255, 255 };   // Sky Blue
+BLUE       :: Color.{ 0, 121, 241, 255 };     // Blue
+DARKBLUE   :: Color.{ 0, 82, 172, 255 };      // Dark Blue
+PURPLE     :: Color.{ 200, 122, 255, 255 };   // Purple
+VIOLET     :: Color.{ 135, 60, 190, 255 };    // Violet
+DARKPURPLE :: Color.{ 112, 31, 126, 255 };    // Dark Purple
+BEIGE      :: Color.{ 211, 176, 131, 255 };   // Beige
+BROWN      :: Color.{ 127, 106, 79, 255 };    // Brown
+DARKBROWN  :: Color.{ 76, 63, 47, 255 };      // Dark Brown
+WHITE      :: Color.{ 255, 255, 255, 255 };   // White
+BLACK      :: Color.{ 0, 0, 0, 255 };         // Black
+BLANK      :: Color.{ 0, 0, 0, 0 };           // Blank (Transparent)
+MAGENTA    :: Color.{ 255, 0, 255, 255 };     // Magenta
+RAYWHITE   :: Color.{ 245, 245, 245, 255 };   // My own White (raylib logo)
 
 #local
 __foreign_block :: #foreign PACKAGE_NAME {
@@ -251,7 +277,7 @@ __foreign_block :: #foreign PACKAGE_NAME {
     UpdateCameraPro :: (camera: &Camera, movement: Vector3, rotation: Vector3, zoom: f32) -> void ---
 
     SetShapesTexture :: (texture: Texture2D, source: Rectangle) -> void ---
-    
+
     DrawPixel :: (posX, posY: i32, color: Color) -> void ---
     DrawPixelV :: (pos: Vector2, color: Color) -> void ---
     DrawLine :: (startX, startY, endX, endY: i32, color: Color) -> void ---
@@ -301,7 +327,7 @@ __foreign_block :: #foreign PACKAGE_NAME {
     CheckCollisionRecs :: (rec1, rec2: Rectangle) -> bool ---
     CheckCollisionCircles :: (center1: Vector2, radius1: f32, center2: Vector2, radius2: f32) -> bool ---
     CheckCollisionCircleRec :: (center: Vector2, radius: f32, rec: Rectangle) -> bool ---
-    CheckCollisionPointRec :: (point: Vector2, rec: Rectangle) -> bool --- 
+    CheckCollisionPointRec :: (point: Vector2, rec: Rectangle) -> bool ---
     CheckCollisionPointCircle :: (point: Vector2, center: Vector2, radius: f32) -> bool ---
     CheckCollisionPointTriangle :: (pointer: Vector2, p1, p2, p3: Vector2) -> bool ---
     CheckCollisionPointPoly :: (point: Vector2, points: [] Vector2) -> bool ---
@@ -309,7 +335,7 @@ __foreign_block :: #foreign PACKAGE_NAME {
     CheckCollisionPointLine :: (point: Vector2, p1, p2: Vector2, threshold: i32) -> bool ---
     @last_arg_is_return_value
     GetCollisionRec :: (rec1, rec2: Rectangle, out: &Rectangle) -> void ---
-    
+
     @last_arg_is_return_value
     LoadImage :: (filename: cstr, out: &Image) -> void ---
     @last_arg_is_return_value
@@ -479,7 +505,7 @@ __foreign_block :: #foreign PACKAGE_NAME {
     UnloadFontData :: (glyphs: cptr(GlyphInfo), glyphCount: i32) -> void ---
     UnloadFont :: (font: Font) -> void ---
     ExportFontAsCode :: (font: Font, filename: cstr) -> bool ---
-    
+
     DrawFPS :: (posX, posY: i32) -> void ---
     DrawText :: (text: cstr, posX, posY: i32, fontSize: i32, color: Color) -> void ---
     DrawTextEx :: (font: Font, text: cstr, pos: Vector2, fontSize: f32, spacing: f32, tint: Color) -> void ---


### PR DESCRIPTION
This PR fixes #1. It also adds raylib's basic color palette constants.